### PR TITLE
Quote positional parameter to supress word-splitting

### DIFF
--- a/bin/since-unreleased.sh
+++ b/bin/since-unreleased.sh
@@ -13,4 +13,4 @@
 # @note `sed -Ei` Same as -E -i with no backup suffix - FILE will be edited in-place without creating a backup.
 # -exec sed -Ei "s/@unreleased/@since $2/g" {} \;
 
-find $1 -type f \( -name "*.php" -o -name "*.js" -o -name "*.jsx" \) -not \( -path "./vendor/*" -o -path "./node_modules/*" \) -exec sed -Ei "s/@unreleased/@since $2/g" {} \;
+find "$1" -type f \( -name "*.php" -o -name "*.js" -o -name "*.jsx" \) -not \( -path "./vendor/*" -o -path "./node_modules/*" \) -exec sed -Ei "s/@unreleased/@since $2/g" {} \;


### PR DESCRIPTION
This change quotes positional parameter 1 (`$1`) to prevent word-splitting on special characters. More details on this behavior are described in https://www.shellcheck.net/wiki/SC2086 and https://mywiki.wooledge.org/Quotes